### PR TITLE
Prettier eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: ['eslint-config-prettier'],
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# Add files here to ignore them from prettier formatting
+
+dist
+pnpm-lock.yaml
+
+CODEOWNERS

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  printWidth: 100,
+  singleQuote: true,
+  semi: false,
+}

--- a/dist/CypressCTRspackPlugin.js
+++ b/dist/CypressCTRspackPlugin.js
@@ -21,6 +21,7 @@ class CypressCTRspackPlugin {
         this.files = [];
         this.compilation = null;
         this.addLoaderContext = (loaderContext, module) => {
+            ;
             loaderContext._cypress = {
                 files: this.files,
                 projectRoot: this.projectRoot,
@@ -35,7 +36,7 @@ class CypressCTRspackPlugin {
             }
             // Ensure we don't try to load files that have been removed from the file system
             // but have not yet been detected by the onSpecsChange handler
-            const foundFiles = (await Promise.all(this.files.map(async (file) => {
+            const foundFiles = await Promise.all(this.files.map(async (file) => {
                 try {
                     const exists = await fs_extra_1.default.pathExists(file.absolute);
                     return exists ? file : null;
@@ -43,7 +44,7 @@ class CypressCTRspackPlugin {
                 catch (e) {
                     return null;
                 }
-            })));
+            }));
             this.files = foundFiles.filter((file) => file !== null);
             callback();
         };

--- a/dist/aut-runner.js
+++ b/dist/aut-runner.js
@@ -2,9 +2,9 @@
 /* eslint-env browser */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.init = void 0;
-function init(importPromises, parent = (window.opener || window.parent)) {
+function init(importPromises, parent = window.opener || window.parent) {
     // @ts-expect-error
-    const Cypress = window.Cypress = parent.Cypress;
+    const Cypress = (window.Cypress = parent.Cypress);
     if (!Cypress) {
         throw new Error('Tests cannot run without a reference to Cypress!');
     }

--- a/dist/createRspackDevServer.js
+++ b/dist/createRspackDevServer.js
@@ -7,10 +7,10 @@ const makeRspackConfig_1 = require("./makeRspackConfig");
 const debug = (0, debug_1.default)('cypress:rspack-dev-server:start');
 async function createRspackDevServer(config) {
     var _a;
-    const { sourceRspackModulesResult: { rspack: { module: rspack, }, rspackDevServer: { majorVersion: rspackDevServerMajorVersion, }, }, } = config;
+    const { sourceRspackModulesResult: { rspack: { module: rspack }, rspackDevServer: { majorVersion: rspackDevServerMajorVersion }, }, } = config;
     const finalRspackConfig = await (0, makeRspackConfig_1.makeRspackConfig)(config);
     const rspackCompiler = rspack(finalRspackConfig, undefined);
-    const { devServerConfig: { cypressConfig: { devServerPublicPathRoute } } } = config;
+    const { devServerConfig: { cypressConfig: { devServerPublicPathRoute }, }, } = config;
     const isOpenMode = !config.devServerConfig.cypressConfig.isTextTerminal;
     const RspackDevServer = config.sourceRspackModulesResult.rspackDevServer.module;
     const rspackDevServerConfig = Object.assign(Object.assign({ host: '127.0.0.1', port: 'auto' }, finalRspackConfig === null || finalRspackConfig === void 0 ? void 0 : finalRspackConfig.devServer), { devMiddleware: {

--- a/dist/devServer.js
+++ b/dist/devServer.js
@@ -17,8 +17,10 @@ const debug = (0, debug_1.default)('cypress:rspack-dev-server:devServer');
  */
 function devServer(devServerConfig) {
     return new Promise(async (resolve, reject) => {
-        const result = await devServer.create(devServerConfig);
-        result.server.start().then(() => {
+        const result = (await devServer.create(devServerConfig));
+        result.server
+            .start()
+            .then(() => {
             if (!result.server.options.port) {
                 return reject(new Error(`Expected port ${result.server.options.port} to be a number`));
             }
@@ -28,12 +30,17 @@ function devServer(devServerConfig) {
                 // Close is for unit testing only. We kill this child process which will handle the closing of the server
                 close: async (done) => {
                     debug('closing dev server');
-                    result.server.stop().then(() => done === null || done === void 0 ? void 0 : done()).catch(done).finally(() => {
+                    result.server
+                        .stop()
+                        .then(() => done === null || done === void 0 ? void 0 : done())
+                        .catch(done)
+                        .finally(() => {
                         debug('closed dev server');
                     });
                 },
             });
-        }).catch(reject);
+        })
+            .catch(reject);
     });
 }
 exports.devServer = devServer;
@@ -43,12 +50,14 @@ const thirdPartyDefinitionPrefixes = {
     globalPrefix: 'cypress-ct-',
 };
 function isThirdPartyDefinition(framework) {
-    return framework.startsWith(thirdPartyDefinitionPrefixes.globalPrefix) ||
-        thirdPartyDefinitionPrefixes.namespacedPrefixRe.test(framework);
+    return (framework.startsWith(thirdPartyDefinitionPrefixes.globalPrefix) ||
+        thirdPartyDefinitionPrefixes.namespacedPrefixRe.test(framework));
 }
 exports.isThirdPartyDefinition = isThirdPartyDefinition;
 async function getPreset(devServerConfig) {
-    const defaultRspackModules = () => ({ sourceRspackModulesResult: (0, sourceRelativeRspackModules_1.sourceDefaultRspackDependencies)(devServerConfig) });
+    const defaultRspackModules = () => ({
+        sourceRspackModulesResult: (0, sourceRelativeRspackModules_1.sourceDefaultRspackDependencies)(devServerConfig),
+    });
     // Third party library (eg solid-js, lit, etc)
     if (devServerConfig.framework && isThirdPartyDefinition(devServerConfig.framework)) {
         return defaultRspackModules();

--- a/dist/helpers/sourceRelativeRspackModules.js
+++ b/dist/helpers/sourceRelativeRspackModules.js
@@ -17,12 +17,12 @@ exports.cypressWebpackPath = cypressWebpackPath;
 const frameworkWebpackMapper = {
     'create-react-app': 'react-scripts',
     'vue-cli': '@vue/cli-service',
-    'nuxt': '@nuxt/rspack',
+    nuxt: '@nuxt/rspack',
     react: undefined,
     vue: undefined,
     next: 'next',
-    'angular': '@angular-devkit/build-angular',
-    'svelte': undefined,
+    angular: '@angular-devkit/build-angular',
+    svelte: undefined,
 };
 // Source the users framework from the provided projectRoot. The framework, if available, will serve
 // as the resolve base for rspack dependency resolution.
@@ -97,7 +97,7 @@ function sourceRspack(config, framework) {
         return originalModuleLoad(request, parent, isMain);
     };
     module_1.default._resolveFilename = function (request, parent, isMain, options) {
-        if (request === 'webpack' || request.startsWith('rspack/') && !(options === null || options === void 0 ? void 0 : options.paths)) {
+        if (request === 'webpack' || (request.startsWith('rspack/') && !(options === null || options === void 0 ? void 0 : options.paths))) {
             const resolveFilename = originalModuleResolveFilename(request, parent, isMain, {
                 paths: [rspack.importPath],
             });
@@ -162,6 +162,7 @@ function getMajorVersion(json, acceptedVersions) {
 }
 exports.getMajorVersion = getMajorVersion;
 function restoreLoadHook() {
+    ;
     module_1.default._load = originalModuleLoad;
     module_1.default._resolveFilename = originalModuleResolveFilename;
 }

--- a/dist/loader.js
+++ b/dist/loader.js
@@ -42,9 +42,11 @@ function buildSpecs(projectRoot, files = []) {
     if (!Array.isArray(files))
         return `{}`;
     debug(`projectRoot: ${projectRoot}, files: ${files.map((f) => f.absolute).join(',')}`);
-    return `{${files.map((f, i) => {
+    return `{${files
+        .map((f, i) => {
         return makeImport(f, f.name, `spec-${i}`, projectRoot);
-    }).join(',')}}`;
+    })
+        .join(',')}}`;
 }
 // Runs the tests inside the iframe
 function loader() {
@@ -54,8 +56,12 @@ function loader() {
     // we regenerate our specs and include any new ones in the compilation.
     ctx.cacheable(false);
     const { files, projectRoot, supportFile } = ctx._cypress;
-    const supportFileAbsolutePath = supportFile ? JSON.stringify(path.resolve(projectRoot, supportFile)) : undefined;
-    const supportFileRelativePath = supportFile ? JSON.stringify(path.relative(projectRoot, supportFileAbsolutePath || '')) : undefined;
+    const supportFileAbsolutePath = supportFile
+        ? JSON.stringify(path.resolve(projectRoot, supportFile))
+        : undefined;
+    const supportFileRelativePath = supportFile
+        ? JSON.stringify(path.relative(projectRoot, supportFileAbsolutePath || ''))
+        : undefined;
     const result = `
   var allTheSpecs = ${buildSpecs(projectRoot, files)};
 

--- a/dist/makeDefaultRspackConfig.d.ts
+++ b/dist/makeDefaultRspackConfig.d.ts
@@ -1,3 +1,3 @@
-import type { Configuration } from '@rspack/core';
+import { type Configuration } from '@rspack/core';
 import type { CreateFinalRspackConfig } from './createRspackDevServer';
 export declare function makeCypressRspackConfig(config: CreateFinalRspackConfig): Configuration;

--- a/dist/makeDefaultRspackConfig.js
+++ b/dist/makeDefaultRspackConfig.js
@@ -11,7 +11,7 @@ const OUTPUT_PATH = path_1.default.join(__dirname, 'dist');
 const OsSeparatorRE = RegExp(`\\${path_1.default.sep}`, 'g');
 const posixSeparator = '/';
 function makeCypressRspackConfig(config) {
-    const { devServerConfig: { cypressConfig: { projectRoot, devServerPublicPathRoute, supportFile, indexHtmlFile, isTextTerminal: isRunMode, }, specs: files, devServerEvents, framework, }, sourceRspackModulesResult: { rspack: { module: rspack, }, }, } = config;
+    const { devServerConfig: { cypressConfig: { projectRoot, devServerPublicPathRoute, supportFile, indexHtmlFile, isTextTerminal: isRunMode, }, specs: files, devServerEvents, framework, }, sourceRspackModulesResult: { rspack: { module: rspack }, }, } = config;
     const optimization = {
         // To prevent files from being tree shaken by rspack, we set optimization.sideEffects: false ensuring that
         // rspack does not recognize the sideEffects flag in the package.json and thus files are not unintentionally
@@ -21,12 +21,11 @@ function makeCypressRspackConfig(config) {
             chunks: 'all',
         },
     };
-    const publicPath = (path_1.default.sep === posixSeparator)
+    const publicPath = path_1.default.sep === posixSeparator
         ? path_1.default.join(devServerPublicPathRoute, posixSeparator)
-        // The second line here replaces backslashes on windows with posix compatible slash
-        // See https://github.com/cypress-io/cypress/issues/16097
-        : path_1.default.join(devServerPublicPathRoute, posixSeparator)
-            .replace(OsSeparatorRE, posixSeparator);
+        : // The second line here replaces backslashes on windows with posix compatible slash
+            // See https://github.com/cypress-io/cypress/issues/16097
+            path_1.default.join(devServerPublicPathRoute, posixSeparator).replace(OsSeparatorRE, posixSeparator);
     const finalConfig = {
         mode: 'development',
         optimization,

--- a/dist/makeRspackConfig.js
+++ b/dist/makeRspackConfig.js
@@ -47,7 +47,7 @@ async function makeRspackConfig(config) {
     var _a, _b, _c;
     let userRspackConfig = config.devServerConfig.rspackConfig;
     const frameworkRspackConfig = config.frameworkConfig;
-    const { cypressConfig: { projectRoot, supportFile, }, specs: files, framework, } = config.devServerConfig;
+    const { cypressConfig: { projectRoot, supportFile }, specs: files, framework, } = config.devServerConfig;
     if (!userRspackConfig && !frameworkRspackConfig) {
         debug('Not user or framework rspack config received. Trying to automatically source it');
         const configFile = await getRspackConfigFromProjectRoot(projectRoot);
@@ -72,9 +72,8 @@ async function makeRspackConfig(config) {
             }
         }
     }
-    userRspackConfig = typeof userRspackConfig === 'function'
-        ? await userRspackConfig()
-        : userRspackConfig;
+    userRspackConfig =
+        typeof userRspackConfig === 'function' ? await userRspackConfig() : userRspackConfig;
     const userAndFrameworkWebpackConfig = modifyRspackConfigForCypress((0, webpack_merge_1.merge)(frameworkRspackConfig !== null && frameworkRspackConfig !== void 0 ? frameworkRspackConfig : {}, userRspackConfig !== null && userRspackConfig !== void 0 ? userRspackConfig : {}));
     debug(`User passed in user and framework webpack config with values %o`, userAndFrameworkWebpackConfig);
     debug(`New webpack entries %o`, files);
@@ -87,7 +86,7 @@ async function makeRspackConfig(config) {
     (_c = mergedConfig.output) === null || _c === void 0 ? true : delete _c.chunkFilename;
     // Angular loads global styles and polyfills via script injection in the index.html
     if (framework === 'angular') {
-        mergedConfig.entry = Object.assign(Object.assign({}, mergedConfig.entry || {}), { 'cypress-entry': exports.CYPRESS_RSPACK_ENTRYPOINT });
+        mergedConfig.entry = Object.assign(Object.assign({}, (mergedConfig.entry || {})), { 'cypress-entry': exports.CYPRESS_RSPACK_ENTRYPOINT });
     }
     else {
         mergedConfig.entry = exports.CYPRESS_RSPACK_ENTRYPOINT;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cypress:open": "pnpm cypress:run-cypress-in-cypress gulp open --project .",
     "test": "pnpm test-unit",
     "test-unit": "mocha -r ts-node/register/transpile-only --config ./test/.mocharc.js",
-    "lint": "eslint --ext .js,.ts,.json, ."
+    "lint": "eslint ."
   },
   "dependencies": {
     "@rspack/cli": "^0.3.11",
@@ -31,10 +31,13 @@
     "@types/fs-extra": "^11.0.1",
     "@types/lodash": "^4.14.195",
     "@types/proxyquire": "^1.3.28",
+    "@typescript-eslint/parser": "^6.11.0",
     "chai": "^4.3.6",
     "cypress": "^12.13.0",
     "debug": "^4.3.4",
     "dedent": "^0.7.0",
+    "eslint": "^8.54.0",
+    "eslint-config-prettier": "^9.0.0",
     "fs-extra": "9.1.0",
     "lodash": "^4.17.21",
     "mocha": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.21",
     "mocha": "^9.2.2",
     "path": "^0.12.7",
+    "prettier": "^3.1.0",
     "proxyquire": "2.1.3",
     "sinon": "^13.0.1",
     "snap-shot-it": "^7.9.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ devDependencies:
   path:
     specifier: ^0.12.7
     version: 0.12.7
+  prettier:
+    specifier: ^3.1.0
+    version: 3.1.0
   proxyquire:
     specifier: 2.1.3
     version: 2.1.3
@@ -2750,6 +2753,12 @@ packages:
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /prettier@3.1.0:
+    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /pretty-bytes@5.6.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ devDependencies:
   '@types/proxyquire':
     specifier: ^1.3.28
     version: 1.3.28
+  '@typescript-eslint/parser':
+    specifier: ^6.11.0
+    version: 6.11.0(eslint@8.54.0)(typescript@5.0.4)
   chai:
     specifier: ^4.3.6
     version: 4.3.6
@@ -52,6 +55,12 @@ devDependencies:
   dedent:
     specifier: ^0.7.0
     version: 0.7.0
+  eslint:
+    specifier: ^8.54.0
+    version: 8.54.0
+  eslint-config-prettier:
+    specifier: ^9.0.0
+    version: 9.0.0(eslint@8.54.0)
   fs-extra:
     specifier: 9.1.0
     version: 9.1.0
@@ -84,6 +93,11 @@ devDependencies:
     version: 5.0.4
 
 packages:
+
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /@bahmutov/data-driven@1.0.0:
     resolution: {integrity: sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==}
@@ -145,6 +159,63 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: false
 
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.54.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.54.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@eslint-community/regexpp@4.10.0:
+    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/eslintrc@2.1.3:
+    resolution: {integrity: sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4(supports-color@8.1.1)
+      espree: 9.6.1
+      globals: 13.23.0
+      ignore: 5.3.0
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@eslint/js@8.54.0:
+    resolution: {integrity: sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@humanwhocodes/config-array@0.11.13:
+    resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.1
+      debug: 4.3.4(supports-color@8.1.1)
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@humanwhocodes/module-importer@1.0.1:
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+    dev: true
+
+  /@humanwhocodes/object-schema@2.0.1:
+    resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    dev: true
+
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -193,6 +264,27 @@ packages:
 
   /@leichtgewicht/ip-codec@2.0.4:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
+
+  /@nodelib/fs.scandir@2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+    dev: true
+
+  /@nodelib/fs.stat@2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /@nodelib/fs.walk@1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.15.0
+    dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0)(webpack-dev-server@4.13.1)(webpack@5.76.0):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
@@ -642,8 +734,75 @@ packages:
     dev: true
     optional: true
 
+  /@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.11.0
+      '@typescript-eslint/types': 6.11.0
+      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.0.4)
+      '@typescript-eslint/visitor-keys': 6.11.0
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.54.0
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager@6.11.0:
+    resolution: {integrity: sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.11.0
+      '@typescript-eslint/visitor-keys': 6.11.0
+    dev: true
+
+  /@typescript-eslint/types@6.11.0:
+    resolution: {integrity: sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.11.0(typescript@5.0.4):
+    resolution: {integrity: sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.11.0
+      '@typescript-eslint/visitor-keys': 6.11.0
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.0.4)
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.11.0:
+    resolution: {integrity: sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.11.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
   /@ungap/promise-all-settled@1.1.2:
     resolution: {integrity: sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==}
+    dev: true
+
+  /@ungap/structured-clone@1.2.0:
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
   /@webassemblyjs/ast@1.11.1:
@@ -757,9 +916,23 @@ packages:
     dependencies:
       acorn: 8.8.2
 
+  /acorn-jsx@5.3.2(acorn@8.11.2):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.11.2
+    dev: true
+
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
+
+  /acorn@8.11.2:
+    resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
 
   /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
@@ -880,6 +1053,11 @@ packages:
 
   /array-flatten@2.1.2:
     resolution: {integrity: sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==}
+
+  /array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+    dev: true
 
   /asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
@@ -1038,6 +1216,11 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.2.1
+
+  /callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+    dev: true
 
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
@@ -1431,6 +1614,10 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
+
   /default-gateway@6.0.3:
     resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
     engines: {node: '>= 10'}
@@ -1476,6 +1663,13 @@ packages:
     engines: {node: '>=0.3.1'}
     dev: true
 
+  /dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-type: 4.0.0
+    dev: true
+
   /disparity@3.0.0:
     resolution: {integrity: sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==}
     engines: {node: '>=8'}
@@ -1493,6 +1687,13 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.4
+
+  /doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      esutils: 2.0.3
+    dev: true
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -1580,12 +1781,97 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /eslint-config-prettier@9.0.0(eslint@8.54.0):
+    resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.54.0
+    dev: true
+
   /eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
+
+  /eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: true
+
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint@8.54.0:
+    resolution: {integrity: sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
+      '@eslint-community/regexpp': 4.10.0
+      '@eslint/eslintrc': 2.1.3
+      '@eslint/js': 8.54.0
+      '@humanwhocodes/config-array': 0.11.13
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.2.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4(supports-color@8.1.1)
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.23.0
+      graphemer: 1.4.0
+      ignore: 5.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.11.2
+      acorn-jsx: 5.3.2(acorn@8.11.2)
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /esquery@1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
 
   /esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -1600,6 +1886,11 @@ packages:
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  /esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1724,13 +2015,34 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  /fast-glob@3.3.2:
+    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  /fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
 
   /fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
     dependencies:
       fast-decode-uri-component: 1.0.1
+
+  /fastq@1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+    dependencies:
+      reusify: 1.0.4
+    dev: true
 
   /faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
@@ -1749,6 +2061,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       escape-string-regexp: 1.0.5
+    dev: true
+
+  /file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flat-cache: 3.2.0
     dev: true
 
   /fill-keys@1.0.2:
@@ -1794,9 +2113,22 @@ packages:
       path-exists: 5.0.0
     dev: false
 
+  /flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flatted: 3.2.9
+      keyv: 4.5.4
+      rimraf: 3.0.2
+    dev: true
+
   /flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
+    dev: true
+
+  /flatted@3.2.9:
+    resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
   /folktale@2.3.2:
@@ -1907,6 +2239,13 @@ packages:
     dependencies:
       is-glob: 4.0.3
 
+  /glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -1938,11 +2277,34 @@ packages:
       ini: 2.0.0
     dev: true
 
+  /globals@13.23.0:
+    resolution: {integrity: sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.20.2
+    dev: true
+
+  /globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.2
+      ignore: 5.3.0
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: true
+
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    dev: true
 
   /growl@1.10.5:
     resolution: {integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==}
@@ -2084,6 +2446,24 @@ packages:
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: true
+
+  /ignore@5.3.0:
+    resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
+    engines: {node: '>= 4'}
+    dev: true
+
+  /import-fresh@3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: true
+
+  /imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
     dev: true
 
   /indent-string@4.0.0:
@@ -2270,6 +2650,10 @@ packages:
     hasBin: true
     dev: true
 
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -2285,6 +2669,10 @@ packages:
 
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: true
+
+  /json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
   /json-stringify-safe@5.0.1:
@@ -2318,6 +2706,12 @@ packages:
     resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
     dev: true
 
+  /keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
+
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -2332,6 +2726,14 @@ packages:
   /lazy-ass@1.6.0:
     resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
     engines: {node: '> 0.8'}
+    dev: true
+
+  /levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
     dev: true
 
   /listr2@3.14.0(enquirer@2.3.6):
@@ -2386,6 +2788,10 @@ packages:
 
   /lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: true
+
+  /lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
   /lodash.once@4.1.1:
@@ -2445,6 +2851,11 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  /merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: true
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -2563,6 +2974,10 @@ packages:
     hasBin: true
     dev: true
 
+  /natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -2642,6 +3057,18 @@ packages:
     hasBin: true
     dev: false
 
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+    dev: true
+
   /ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
     dev: true
@@ -2686,6 +3113,13 @@ packages:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  /parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+    dependencies:
+      callsites: 3.1.0
+    dev: true
+
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2717,6 +3151,11 @@ packages:
     resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
     dependencies:
       isarray: 0.0.1
+    dev: true
+
+  /path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
     dev: true
 
   /path@0.12.7:
@@ -2753,6 +3192,11 @@ packages:
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
     dev: true
 
   /prettier@3.1.0:
@@ -2813,6 +3257,10 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
+
+  /queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
 
   /quote@0.4.0:
     resolution: {integrity: sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ==}
@@ -2893,6 +3341,11 @@ packages:
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  /resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+    dev: true
+
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
@@ -2913,6 +3366,11 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  /reusify@1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: true
+
   /rfdc@1.3.0:
     resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
     dev: true
@@ -2922,6 +3380,12 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+
+  /run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    dependencies:
+      queue-microtask: 1.2.3
+    dev: true
 
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -2971,6 +3435,14 @@ packages:
 
   /semver@7.5.1:
     resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -3088,6 +3560,11 @@ packages:
       mrmime: 1.0.1
       totalist: 1.1.0
     dev: false
+
+  /slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+    dev: true
 
   /slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
@@ -3354,6 +3831,10 @@ packages:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  /text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
   /throttleit@1.0.0:
     resolution: {integrity: sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==}
     dev: true
@@ -3393,6 +3874,15 @@ packages:
     dependencies:
       psl: 1.9.0
       punycode: 2.3.0
+    dev: true
+
+  /ts-api-utils@1.0.3(typescript@5.0.4):
+    resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.0.4
     dev: true
 
   /ts-node@10.9.1(@types/node@20.2.5)(typescript@5.0.4):
@@ -3443,9 +3933,21 @@ packages:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: true
 
+  /type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+    dev: true
+
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
+    dev: true
+
+  /type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
     dev: true
 
   /type-fest@0.21.3:

--- a/src/aut-runner.ts
+++ b/src/aut-runner.ts
@@ -1,8 +1,11 @@
 /* eslint-env browser */
 
-export function init (importPromises: Array<() => Promise<void>>, parent: Window = (window.opener || window.parent)) {
+export function init(
+  importPromises: Array<() => Promise<void>>,
+  parent: Window = window.opener || window.parent,
+) {
   // @ts-expect-error
-  const Cypress = window.Cypress = parent.Cypress
+  const Cypress = (window.Cypress = parent.Cypress)
 
   if (!Cypress) {
     throw new Error('Tests cannot run without a reference to Cypress!')

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,5 @@
 function render() {
-  require('!!./loader.js!./browser.js');
+  require('!!./loader.js!./browser.js')
 }
 
-render();
+render()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,4 +3,4 @@ export const configFiles = [
   'rspack.config.js',
   'rspack.config.mjs',
   'rspack.config.cjs',
-];
+]

--- a/src/createRspackDevServer.ts
+++ b/src/createRspackDevServer.ts
@@ -1,10 +1,10 @@
-import debugLib from 'debug';
-import type { Configuration } from '@rspack/dev-server';
-import type { DevServerConfig } from './devServer';
-import type { SourceRelativeRspackResult } from './helpers/sourceRelativeRspackModules';
-import { makeRspackConfig } from './makeRspackConfig';
+import debugLib from 'debug'
+import type { Configuration } from '@rspack/dev-server'
+import type { DevServerConfig } from './devServer'
+import type { SourceRelativeRspackResult } from './helpers/sourceRelativeRspackModules'
+import { makeRspackConfig } from './makeRspackConfig'
 
-const debug = debugLib('cypress:rspack-dev-server:start');
+const debug = debugLib('cypress:rspack-dev-server:start')
 
 /**
  * Takes the rspack / rspackDevServer modules, the configuration provide
@@ -16,37 +16,35 @@ export interface CreateFinalRspackConfig {
   /**
    * Initial config passed to devServer
    */
-  devServerConfig: DevServerConfig;
+  devServerConfig: DevServerConfig
   /**
    * Result of sourcing the rspack from the
    */
-  sourceRspackModulesResult: SourceRelativeRspackResult;
+  sourceRspackModulesResult: SourceRelativeRspackResult
   /**
    * Framework-specific config overrides
    */
-  frameworkConfig?: unknown;
+  frameworkConfig?: unknown
 }
 
-export async function createRspackDevServer(
-  config: CreateFinalRspackConfig,
-) {
+export async function createRspackDevServer(config: CreateFinalRspackConfig) {
   const {
     sourceRspackModulesResult: {
-      rspack: {
-        module: rspack,
-      },
-      rspackDevServer: {
-        majorVersion: rspackDevServerMajorVersion,
-      },
+      rspack: { module: rspack },
+      rspackDevServer: { majorVersion: rspackDevServerMajorVersion },
     },
-  } = config;
+  } = config
 
-  const finalRspackConfig = await makeRspackConfig(config);
-  const rspackCompiler = rspack(finalRspackConfig, undefined);
+  const finalRspackConfig = await makeRspackConfig(config)
+  const rspackCompiler = rspack(finalRspackConfig, undefined)
 
-  const { devServerConfig: { cypressConfig: { devServerPublicPathRoute } } } = config;
-  const isOpenMode = !config.devServerConfig.cypressConfig.isTextTerminal;
-  const RspackDevServer = config.sourceRspackModulesResult.rspackDevServer.module;
+  const {
+    devServerConfig: {
+      cypressConfig: { devServerPublicPathRoute },
+    },
+  } = config
+  const isOpenMode = !config.devServerConfig.cypressConfig.isTextTerminal
+  const RspackDevServer = config.sourceRspackModulesResult.rspackDevServer.module
   const rspackDevServerConfig: Configuration = {
     host: '127.0.0.1',
     port: 'auto',
@@ -61,15 +59,15 @@ export async function createRspackDevServer(
     liveReload: isOpenMode,
     client: {
       overlay: false,
-    }
-  };
+    },
+  }
 
-  const server = new RspackDevServer(rspackDevServerConfig, rspackCompiler);
+  const server = new RspackDevServer(rspackDevServerConfig, rspackCompiler)
 
   return {
     server,
     compiler: rspackCompiler,
-  };
+  }
 
-  throw new Error(`Unsupported webpackDevServer version ${ rspackDevServerMajorVersion }`);
+  throw new Error(`Unsupported webpackDevServer version ${rspackDevServerMajorVersion}`)
 }

--- a/src/devServer.ts
+++ b/src/devServer.ts
@@ -1,27 +1,35 @@
 /// <reference types="cypress" />
 
-import type { Compiler, Configuration } from '@rspack/core';
+import type { Compiler, Configuration } from '@rspack/core'
 
-import { createRspackDevServer } from './createRspackDevServer';
-import debugLib from 'debug';
-import { sourceDefaultRspackDependencies, SourceRelativeRspackResult } from './helpers/sourceRelativeRspackModules';
-import type { RspackDevServer } from '@rspack/dev-server';
+import { createRspackDevServer } from './createRspackDevServer'
+import debugLib from 'debug'
+import {
+  sourceDefaultRspackDependencies,
+  SourceRelativeRspackResult,
+} from './helpers/sourceRelativeRspackModules'
+import type { RspackDevServer } from '@rspack/dev-server'
 
-const debug = debugLib('cypress:rspack-dev-server:devServer');
+const debug = debugLib('cypress:rspack-dev-server:devServer')
 
-export type Frameworks = Extract<Cypress.DevServerConfigOptions, { bundler: 'webpack' }>['framework']
+export type Frameworks = Extract<
+  Cypress.DevServerConfigOptions,
+  { bundler: 'webpack' }
+>['framework']
 
-type FrameworkConfig = {
-  framework?: Exclude<Frameworks, 'angular'>
-} | {
-  framework: 'angular'
-  options?: {
-    projectConfig: Cypress.AngularDevServerProjectConfig
-  }
-}
+type FrameworkConfig =
+  | {
+      framework?: Exclude<Frameworks, 'angular'>
+    }
+  | {
+      framework: 'angular'
+      options?: {
+        projectConfig: Cypress.AngularDevServerProjectConfig
+      }
+    }
 
 export type ConfigHandler =
-  Partial<Configuration>
+  | Partial<Configuration>
   | (() => Partial<Configuration> | Promise<Partial<Configuration>>)
 
 export type DevServerConfig = {
@@ -49,33 +57,42 @@ type DevServerCreateResult = {
  *
  * @param config
  */
-export function devServer(devServerConfig: DevServerConfig): Promise<Cypress.ResolvedDevServerConfig> {
+export function devServer(
+  devServerConfig: DevServerConfig,
+): Promise<Cypress.ResolvedDevServerConfig> {
   return new Promise(async (resolve, reject) => {
-    const result = await devServer.create(devServerConfig) as DevServerCreateResult;
+    const result = (await devServer.create(devServerConfig)) as DevServerCreateResult
 
-    result.server.start().then(() => {
-      if (!result.server.options.port) {
-        return reject(new Error(`Expected port ${ result.server.options.port } to be a number`));
-      }
+    result.server
+      .start()
+      .then(() => {
+        if (!result.server.options.port) {
+          return reject(new Error(`Expected port ${result.server.options.port} to be a number`))
+        }
 
-      debug('Component testing rspack server 4 started on port %s', result.server.options.port);
+        debug('Component testing rspack server 4 started on port %s', result.server.options.port)
 
-      resolve({
-        port: result.server.options.port as number,
-        // Close is for unit testing only. We kill this child process which will handle the closing of the server
-        close: async (done) => {
-          debug('closing dev server')
-          result.server.stop().then(() => done?.()).catch(done).finally(() => {
-            debug('closed dev server')
-          })
-        },
+        resolve({
+          port: result.server.options.port as number,
+          // Close is for unit testing only. We kill this child process which will handle the closing of the server
+          close: async (done) => {
+            debug('closing dev server')
+            result.server
+              .stop()
+              .then(() => done?.())
+              .catch(done)
+              .finally(() => {
+                debug('closed dev server')
+              })
+          },
+        })
       })
-    }).catch(reject)
+      .catch(reject)
   })
 }
 
 export type PresetHandlerResult = {
-  frameworkConfig: Configuration,
+  frameworkConfig: Configuration
   sourceRspackModulesResult: SourceRelativeRspackResult
 }
 
@@ -87,17 +104,23 @@ const thirdPartyDefinitionPrefixes = {
   globalPrefix: 'cypress-ct-',
 }
 
-export function isThirdPartyDefinition (framework: string) {
-  return framework.startsWith(thirdPartyDefinitionPrefixes.globalPrefix) ||
+export function isThirdPartyDefinition(framework: string) {
+  return (
+    framework.startsWith(thirdPartyDefinitionPrefixes.globalPrefix) ||
     thirdPartyDefinitionPrefixes.namespacedPrefixRe.test(framework)
+  )
 }
 
-async function getPreset(devServerConfig: DevServerConfig): Promise<Optional<PresetHandlerResult, 'frameworkConfig'>> {
-  const defaultRspackModules = () => ({ sourceRspackModulesResult: sourceDefaultRspackDependencies(devServerConfig) });
+async function getPreset(
+  devServerConfig: DevServerConfig,
+): Promise<Optional<PresetHandlerResult, 'frameworkConfig'>> {
+  const defaultRspackModules = () => ({
+    sourceRspackModulesResult: sourceDefaultRspackDependencies(devServerConfig),
+  })
 
   // Third party library (eg solid-js, lit, etc)
   if (devServerConfig.framework && isThirdPartyDefinition(devServerConfig.framework)) {
-    return defaultRspackModules();
+    return defaultRspackModules()
   }
 
   switch (devServerConfig.framework) {
@@ -120,10 +143,14 @@ async function getPreset(devServerConfig: DevServerConfig): Promise<Optional<Pre
     case 'vue':
     case 'svelte':
     case undefined:
-      return defaultRspackModules();
+      return defaultRspackModules()
 
     default:
-      throw new Error(`Unexpected framework ${(devServerConfig as any).framework}, please visit https://on.cypress.io/component-framework-configuration to see a list of supported frameworks`)
+      throw new Error(
+        `Unexpected framework ${
+          (devServerConfig as any).framework
+        }, please visit https://on.cypress.io/component-framework-configuration to see a list of supported frameworks`,
+      )
   }
 }
 
@@ -134,19 +161,19 @@ async function getPreset(devServerConfig: DevServerConfig): Promise<Optional<Pre
  * @internal
  */
 devServer.create = async function (devServerConfig: DevServerConfig) {
-  const { frameworkConfig, sourceRspackModulesResult } = await getPreset(devServerConfig);
+  const { frameworkConfig, sourceRspackModulesResult } = await getPreset(devServerConfig)
 
   const { server, compiler } = await createRspackDevServer({
     devServerConfig,
     frameworkConfig,
     sourceRspackModulesResult,
-  });
+  })
 
   const result = {
     server,
     compiler,
     version: sourceRspackModulesResult.rspackDevServer.majorVersion,
-  };
+  }
 
   return result
 }

--- a/src/helpers/sourceRelativeRspackModules.ts
+++ b/src/helpers/sourceRelativeRspackModules.ts
@@ -1,243 +1,255 @@
-import Module from 'module';
-import path from 'path';
-import type { DevServerConfig, Frameworks } from '../devServer';
-import debugFn from 'debug';
-import type { RspackDevServer } from '@rspack/dev-server';
+import Module from 'module'
+import path from 'path'
+import type { DevServerConfig, Frameworks } from '../devServer'
+import debugFn from 'debug'
+import type { RspackDevServer } from '@rspack/dev-server'
 
-const debug = debugFn('cypress:rspack-dev-server:sourceRelativeRspackModules');
+const debug = debugFn('cypress:rspack-dev-server:sourceRelativeRspackModules')
 
 export type ModuleClass = typeof Module & {
   _load(id: string, parent: Module, isMain: boolean): any
-  _resolveFilename(request: string, parent: Module, isMain: boolean, options?: { paths: string[] }): string
+  _resolveFilename(
+    request: string,
+    parent: Module,
+    isMain: boolean,
+    options?: { paths: string[] },
+  ): string
   _cache: Record<string, Module>
 }
 
 export interface PackageJson {
-  name: string;
-  version: string;
+  name: string
+  version: string
 }
 
 export interface SourcedDependency {
-  importPath: string;
-  packageJson: PackageJson;
+  importPath: string
+  packageJson: PackageJson
 }
 
 export interface SourcedRspack extends SourcedDependency {
-  module: Function;
-  majorVersion: 0;
+  module: Function
+  majorVersion: 0
 }
 
 export interface SourcedRspackDevServer extends SourcedDependency {
   module: {
-    new(...args: unknown[]): RspackDevServer
-  };
-  majorVersion: 0;
+    new (...args: unknown[]): RspackDevServer
+  }
+  majorVersion: 0
 }
 
 export interface SourceRelativeRspackResult {
-  framework: SourcedDependency | null;
-  rspack: SourcedRspack;
-  rspackDevServer: SourcedRspackDevServer;
+  framework: SourcedDependency | null
+  rspack: SourcedRspack
+  rspackDevServer: SourcedRspackDevServer
 }
 
-const originalModuleLoad = (Module as ModuleClass)._load;
-const originalModuleResolveFilename = (Module as ModuleClass)._resolveFilename;
+const originalModuleLoad = (Module as ModuleClass)._load
+const originalModuleResolveFilename = (Module as ModuleClass)._resolveFilename
 
 export const cypressWebpackPath = (config: DevServerConfig) => {
   return require.resolve('@cypress/rspack-batteries-included-preprocessor', {
     paths: [config.cypressConfig.cypressBinaryRoot],
-  });
-};
+  })
+}
 
 type FrameworkWebpackMapper = { [Property in Frameworks]: string | undefined }
 
 const frameworkWebpackMapper: FrameworkWebpackMapper = {
   'create-react-app': 'react-scripts',
   'vue-cli': '@vue/cli-service',
-  'nuxt': '@nuxt/rspack',
+  nuxt: '@nuxt/rspack',
   react: undefined,
   vue: undefined,
   next: 'next',
-  'angular': '@angular-devkit/build-angular',
-  'svelte': undefined,
-};
+  angular: '@angular-devkit/build-angular',
+  svelte: undefined,
+}
 
 // Source the users framework from the provided projectRoot. The framework, if available, will serve
 // as the resolve base for rspack dependency resolution.
 export function sourceFramework(config: DevServerConfig): SourcedDependency | null {
-  debug('Framework: Attempting to source framework for %s', config.cypressConfig.projectRoot);
+  debug('Framework: Attempting to source framework for %s', config.cypressConfig.projectRoot)
   if (!config.framework) {
-    debug('Framework: No framework provided');
+    debug('Framework: No framework provided')
 
-    return null;
+    return null
   }
 
-  const sourceOfWebpack = frameworkWebpackMapper[config.framework];
+  const sourceOfWebpack = frameworkWebpackMapper[config.framework]
 
   if (!sourceOfWebpack) {
-    debug('Not a higher-order framework so rspack dependencies should be resolvable from projectRoot');
+    debug(
+      'Not a higher-order framework so rspack dependencies should be resolvable from projectRoot',
+    )
 
-    return null;
+    return null
   }
 
-  const framework = {} as SourcedDependency;
+  const framework = {} as SourcedDependency
 
   try {
-    const frameworkJsonPath = require.resolve(`${ sourceOfWebpack }/package.json`, {
+    const frameworkJsonPath = require.resolve(`${sourceOfWebpack}/package.json`, {
       paths: [config.cypressConfig.projectRoot],
-    });
-    const frameworkPathRoot = path.dirname(frameworkJsonPath);
+    })
+    const frameworkPathRoot = path.dirname(frameworkJsonPath)
 
     // Want to make sure we're sourcing this from the user's code. Otherwise we can
     // warn and tell them they don't have their dependencies installed
-    framework.importPath = frameworkPathRoot;
-    framework.packageJson = require(frameworkJsonPath);
+    framework.importPath = frameworkPathRoot
+    framework.packageJson = require(frameworkJsonPath)
 
-    debug('Framework: Successfully sourced framework - %o', framework);
+    debug('Framework: Successfully sourced framework - %o', framework)
 
-    return framework;
+    return framework
   } catch (e) {
-    debug('Framework: Failed to source framework - %s', e);
+    debug('Framework: Failed to source framework - %s', e)
 
     // TODO
-    return null;
+    return null
   }
 }
 
 // Source the rspack module from the provided framework or projectRoot. We override the module resolution
 // so that other packages that import rspack resolve to the version we found.
 // If none is found, we fallback to the bundled version in '@cypress/rspack-batteries-included-preprocessor'.
-export function sourceRspack(config: DevServerConfig, framework: SourcedDependency | null): SourcedRspack {
-  const searchRoot = framework?.importPath ?? config.cypressConfig.projectRoot;
+export function sourceRspack(
+  config: DevServerConfig,
+  framework: SourcedDependency | null,
+): SourcedRspack {
+  const searchRoot = framework?.importPath ?? config.cypressConfig.projectRoot
 
-  debug('Rspack: Attempting to source rspack from %s', searchRoot);
+  debug('Rspack: Attempting to source rspack from %s', searchRoot)
 
-  const rspack = {} as SourcedRspack;
+  const rspack = {} as SourcedRspack
 
-  let rspackJsonPath: string;
+  let rspackJsonPath: string
 
   try {
     rspackJsonPath = require.resolve('@rspack/core/package.json', {
       paths: [searchRoot],
-    });
+    })
   } catch (e) {
     if ((e as { code?: string }).code !== 'MODULE_NOT_FOUND') {
-      debug('Rspack: Failed to source rspack - %s', e);
-      throw e;
+      debug('Rspack: Failed to source rspack - %s', e)
+      throw e
     }
 
-    debug('rspack: Falling back to bundled version');
+    debug('rspack: Falling back to bundled version')
 
     rspackJsonPath = require.resolve('@rspack/core/package.json', {
       paths: [cypressWebpackPath(config)],
-    });
+    })
   }
 
-  rspack.importPath = path.dirname(rspackJsonPath);
-  rspack.packageJson = require(rspackJsonPath);
-  rspack.module = require(rspack.importPath).rspack;
-  rspack.majorVersion = getMajorVersion(rspack.packageJson, [0]);
+  rspack.importPath = path.dirname(rspackJsonPath)
+  rspack.packageJson = require(rspackJsonPath)
+  rspack.module = require(rspack.importPath).rspack
+  rspack.majorVersion = getMajorVersion(rspack.packageJson, [0])
 
   debug('Webpack: Successfully sourced rspack - %o', rspack)
-
   ;(Module as ModuleClass)._load = function (request, parent, isMain) {
     if (request === 'webpack' || request.startsWith('rspack/')) {
       const resolvePath = require.resolve(request, {
         paths: [rspack.importPath],
-      });
+      })
 
-      debug('Rspack: Module._load resolvePath - %s', resolvePath);
+      debug('Rspack: Module._load resolvePath - %s', resolvePath)
 
-      return originalModuleLoad(resolvePath, parent, isMain);
+      return originalModuleLoad(resolvePath, parent, isMain)
     }
 
-    return originalModuleLoad(request, parent, isMain);
+    return originalModuleLoad(request, parent, isMain)
   }
-
   ;(Module as ModuleClass)._resolveFilename = function (request, parent, isMain, options) {
-    if (request === 'webpack' || request.startsWith('rspack/') && !options?.paths) {
+    if (request === 'webpack' || (request.startsWith('rspack/') && !options?.paths)) {
       const resolveFilename = originalModuleResolveFilename(request, parent, isMain, {
         paths: [rspack.importPath],
-      });
+      })
 
-      debug('Webpack: Module._resolveFilename resolveFilename - %s', resolveFilename);
+      debug('Webpack: Module._resolveFilename resolveFilename - %s', resolveFilename)
 
-      return resolveFilename;
+      return resolveFilename
     }
 
-    return originalModuleResolveFilename(request, parent, isMain, options);
-  };
+    return originalModuleResolveFilename(request, parent, isMain, options)
+  }
 
-  return rspack;
+  return rspack
 }
 
 // Source the rspack-dev-server module from the provided framework or projectRoot.
 // If none is found, we fallback to the version bundled with this package.
 export function sourceRspackDevServer(
   config: DevServerConfig,
-  framework?: SourcedDependency | null): SourcedRspackDevServer {
-  const searchRoot = framework?.importPath ?? config.cypressConfig.projectRoot;
+  framework?: SourcedDependency | null,
+): SourcedRspackDevServer {
+  const searchRoot = framework?.importPath ?? config.cypressConfig.projectRoot
 
-  debug('WebpackDevServer: Attempting to source rspack-dev-server from %s', searchRoot);
+  debug('WebpackDevServer: Attempting to source rspack-dev-server from %s', searchRoot)
 
-  const rspackDevServer = {} as SourcedRspackDevServer;
-  let rspackDevServerJsonPath: string;
+  const rspackDevServer = {} as SourcedRspackDevServer
+  let rspackDevServerJsonPath: string
 
   try {
     rspackDevServerJsonPath = require.resolve('@rspack/dev-server/package.json', {
       paths: [searchRoot],
-    });
+    })
   } catch (e) {
     if ((e as { code?: string }).code !== 'MODULE_NOT_FOUND') {
-      debug('RspackDevServer: Failed to source @rspack/dev-server - %s', e);
-      throw e;
+      debug('RspackDevServer: Failed to source @rspack/dev-server - %s', e)
+      throw e
     }
 
-    debug('WebpackDevServer: Falling back to bundled version');
+    debug('WebpackDevServer: Falling back to bundled version')
 
     rspackDevServerJsonPath = require.resolve('@rspack/dev-server/package.json', {
       paths: [__dirname],
-    });
+    })
   }
 
-  rspackDevServer.importPath = path.dirname(rspackDevServerJsonPath);
-  rspackDevServer.packageJson = require(rspackDevServerJsonPath);
-  rspackDevServer.module = require(rspackDevServer.importPath).RspackDevServer;
-  rspackDevServer.majorVersion = getMajorVersion(rspackDevServer.packageJson, [0]);
+  rspackDevServer.importPath = path.dirname(rspackDevServerJsonPath)
+  rspackDevServer.packageJson = require(rspackDevServerJsonPath)
+  rspackDevServer.module = require(rspackDevServer.importPath).RspackDevServer
+  rspackDevServer.majorVersion = getMajorVersion(rspackDevServer.packageJson, [0])
 
-  debug('WebpackDevServer: Successfully sourced rspack-dev-server - %o', rspackDevServer);
+  debug('WebpackDevServer: Successfully sourced rspack-dev-server - %o', rspackDevServer)
 
-  return rspackDevServer;
+  return rspackDevServer
 }
 
-
 // Most frameworks follow a similar path for sourcing rspack dependencies so this is a utility to handle all the sourcing.
-export function sourceDefaultRspackDependencies(config: DevServerConfig): SourceRelativeRspackResult {
-  const framework = sourceFramework(config);
-  const webpack = sourceRspack(config, framework);
-  const webpackDevServer = sourceRspackDevServer(config, framework);
+export function sourceDefaultRspackDependencies(
+  config: DevServerConfig,
+): SourceRelativeRspackResult {
+  const framework = sourceFramework(config)
+  const webpack = sourceRspack(config, framework)
+  const webpackDevServer = sourceRspackDevServer(config, framework)
 
   return {
     framework,
     rspack: webpack,
     rspackDevServer: webpackDevServer,
-  };
+  }
 }
 
 export function getMajorVersion<T extends number>(json: PackageJson, acceptedVersions: T[]): T {
-  const major = Number(json.version.split('.')[0]);
+  const major = Number(json.version.split('.')[0])
 
   if (!acceptedVersions.includes(major as T)) {
     throw new Error(
-      `Unexpected major version of ${ json.name }. ` +
-      `Cypress webpack-dev-server works with ${ json.name } versions ${ acceptedVersions.join(', ') } - saw ${ json.version }`,
-    );
+      `Unexpected major version of ${json.name}. ` +
+        `Cypress webpack-dev-server works with ${json.name} versions ${acceptedVersions.join(
+          ', ',
+        )} - saw ${json.version}`,
+    )
   }
 
-  return Number(major) as T;
+  return Number(major) as T
 }
 
 export function restoreLoadHook() {
-  (Module as ModuleClass)._load = originalModuleLoad;
-  (Module as ModuleClass)._resolveFilename = originalModuleResolveFilename;
+  ;(Module as ModuleClass)._load = originalModuleLoad
+  ;(Module as ModuleClass)._resolveFilename = originalModuleResolveFilename
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,12 +1,12 @@
 /* global Cypress */
 /// <reference types="cypress" />
 
-import debugFn from 'debug';
-import * as path from 'path';
-import type { LoaderContext } from '@rspack/core';
-import type { CypressCTRspackContext } from './CypressCTRspackPlugin';
+import debugFn from 'debug'
+import * as path from 'path'
+import type { LoaderContext } from '@rspack/core'
+import type { CypressCTRspackContext } from './CypressCTRspackPlugin'
 
-const debug = debugFn('cypress:rspack-dev-server:rspack');
+const debug = debugFn('cypress:rspack-dev-server:rspack')
 
 /**
  * @param {ComponentSpec} file spec to create import string from.
@@ -14,18 +14,23 @@ const debug = debugFn('cypress:rspack-dev-server:rspack');
  * @param {string} chunkName rspack chunk name. eg: 'spec-0'
  * @param {string} projectRoot absolute path to the project root. eg: /Users/<username>/my-app
  */
-const makeImport = (file: Cypress.Cypress['spec'], filename: string, chunkName: string, projectRoot: string) => {
+const makeImport = (
+  file: Cypress.Cypress['spec'],
+  filename: string,
+  chunkName: string,
+  projectRoot: string,
+) => {
   // If we want to rename the chunks, we can use this
-  const magicComments = chunkName ? `/* webpackChunkName: "${ chunkName }" */` : '';
+  const magicComments = chunkName ? `/* webpackChunkName: "${chunkName}" */` : ''
 
-  return `"${ filename }": {
-    shouldLoad: () => decodeURI(document.location.pathname).includes("${ file.absolute }"),
-    load: () => import(${ magicComments } "${ file.absolute }"),
-    absolute: "${ file.absolute.split(path.sep).join(path.posix.sep) }",
-    relative: "${ file.relative.split(path.sep).join(path.posix.sep) }",
-    relativeUrl: "/__cypress/src/${ chunkName }.js",
-  }`;
-};
+  return `"${filename}": {
+    shouldLoad: () => decodeURI(document.location.pathname).includes("${file.absolute}"),
+    load: () => import(${magicComments} "${file.absolute}"),
+    absolute: "${file.absolute.split(path.sep).join(path.posix.sep)}",
+    relative: "${file.relative.split(path.sep).join(path.posix.sep)}",
+    relativeUrl: "/__cypress/src/${chunkName}.js",
+  }`
+}
 
 /**
  * Creates a object mapping a spec file to an object mapping
@@ -43,31 +48,37 @@ const makeImport = (file: Cypress.Cypress['spec'], filename: string, chunkName: 
  * }
  */
 function buildSpecs(projectRoot: string, files: Cypress.Cypress['spec'][] = []): string {
-  if (!Array.isArray(files)) return `{}`;
+  if (!Array.isArray(files)) return `{}`
 
-  debug(`projectRoot: ${ projectRoot }, files: ${ files.map((f) => f.absolute).join(',') }`);
+  debug(`projectRoot: ${projectRoot}, files: ${files.map((f) => f.absolute).join(',')}`)
 
-  return `{${ files.map((f, i) => {
-    return makeImport(f, f.name, `spec-${ i }`, projectRoot);
-  }).join(',') }}`;
+  return `{${files
+    .map((f, i) => {
+      return makeImport(f, f.name, `spec-${i}`, projectRoot)
+    })
+    .join(',')}}`
 }
 
 // Runs the tests inside the iframe
 export default function loader(this: unknown) {
-  const ctx = this as CypressCTRspackContext & LoaderContext<void>;
+  const ctx = this as CypressCTRspackContext & LoaderContext<void>
 
   // In Webpack 5, a spec added after the dev-server is created won't
   // be included in the compilation. Disabling the caching of this loader ensures
   // we regenerate our specs and include any new ones in the compilation.
-  ctx.cacheable(false);
-  const { files, projectRoot, supportFile } = ctx._cypress;
+  ctx.cacheable(false)
+  const { files, projectRoot, supportFile } = ctx._cypress
 
-  const supportFileAbsolutePath = supportFile ? JSON.stringify(path.resolve(projectRoot, supportFile)) : undefined;
-  const supportFileRelativePath = supportFile ? JSON.stringify(path.relative(projectRoot, supportFileAbsolutePath || '')) : undefined;
+  const supportFileAbsolutePath = supportFile
+    ? JSON.stringify(path.resolve(projectRoot, supportFile))
+    : undefined
+  const supportFileRelativePath = supportFile
+    ? JSON.stringify(path.relative(projectRoot, supportFileAbsolutePath || ''))
+    : undefined
   const result = `
-  var allTheSpecs = ${ buildSpecs(projectRoot, files) };
+  var allTheSpecs = ${buildSpecs(projectRoot, files)};
 
-  var { init } = require(${ JSON.stringify(require.resolve('./aut-runner')) })
+  var { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})
 
   var scriptLoaders = Object.values(allTheSpecs).reduce(
     (accSpecLoaders, specLoader) => {
@@ -77,18 +88,18 @@ export default function loader(this: unknown) {
       return accSpecLoaders
   }, [])
 
-  if (${ !!supportFile }) {
+  if (${!!supportFile}) {
     var supportFile = {
-      absolute: ${ supportFileAbsolutePath },
-      relative: ${ supportFileRelativePath },
+      absolute: ${supportFileAbsolutePath},
+      relative: ${supportFileRelativePath},
       relativeUrl: "/__cypress/src/cypress-support-file.js",
-      load: () => import(/* webpackChunkName: "cypress-support-file" */ ${ supportFileAbsolutePath }),
+      load: () => import(/* webpackChunkName: "cypress-support-file" */ ${supportFileAbsolutePath}),
     }
     scriptLoaders.unshift(supportFile)
   }
 
   init(scriptLoaders)
-  `;
+  `
 
-  return result;
+  return result
 }

--- a/src/makeDefaultRspackConfig.ts
+++ b/src/makeDefaultRspackConfig.ts
@@ -1,19 +1,17 @@
-import path from 'path';
-import debugLib from 'debug';
-import { HtmlRspackPlugin, type Configuration } from '@rspack/core';
-import type { CreateFinalRspackConfig } from './createRspackDevServer';
-import { CypressCTRspackPlugin } from './CypressCTRspackPlugin';
+import path from 'path'
+import debugLib from 'debug'
+import { HtmlRspackPlugin, type Configuration } from '@rspack/core'
+import type { CreateFinalRspackConfig } from './createRspackDevServer'
+import { CypressCTRspackPlugin } from './CypressCTRspackPlugin'
 
-const debug = debugLib('cypress:rspack-dev-server:makeDefaultRspackConfig');
+const debug = debugLib('cypress:rspack-dev-server:makeDefaultRspackConfig')
 
-const OUTPUT_PATH = path.join(__dirname, 'dist');
+const OUTPUT_PATH = path.join(__dirname, 'dist')
 
-const OsSeparatorRE = RegExp(`\\${path.sep}`, 'g');
-const posixSeparator = '/';
+const OsSeparatorRE = RegExp(`\\${path.sep}`, 'g')
+const posixSeparator = '/'
 
-export function makeCypressRspackConfig(
-  config: CreateFinalRspackConfig,
-): Configuration {
+export function makeCypressRspackConfig(config: CreateFinalRspackConfig): Configuration {
   const {
     devServerConfig: {
       cypressConfig: {
@@ -28,12 +26,9 @@ export function makeCypressRspackConfig(
       framework,
     },
     sourceRspackModulesResult: {
-      rspack: {
-        module: rspack,
-      },
+      rspack: { module: rspack },
     },
-  } = config;
-
+  } = config
 
   const optimization: Record<string, any> = {
     // To prevent files from being tree shaken by rspack, we set optimization.sideEffects: false ensuring that
@@ -43,14 +38,14 @@ export function makeCypressRspackConfig(
     splitChunks: {
       chunks: 'all',
     },
-  };
+  }
 
-  const publicPath = (path.sep === posixSeparator)
-    ? path.join(devServerPublicPathRoute, posixSeparator)
-    // The second line here replaces backslashes on windows with posix compatible slash
-    // See https://github.com/cypress-io/cypress/issues/16097
-    : path.join(devServerPublicPathRoute, posixSeparator)
-      .replace(OsSeparatorRE, posixSeparator);
+  const publicPath =
+    path.sep === posixSeparator
+      ? path.join(devServerPublicPathRoute, posixSeparator)
+      : // The second line here replaces backslashes on windows with posix compatible slash
+        // See https://github.com/cypress-io/cypress/issues/16097
+        path.join(devServerPublicPathRoute, posixSeparator).replace(OsSeparatorRE, posixSeparator)
 
   const finalConfig = {
     mode: 'development',
@@ -75,17 +70,17 @@ export function makeCypressRspackConfig(
       }),
     ],
     devtool: 'inline-source-map',
-  } as any;
+  } as any
 
   if (isRunMode) {
     // Disable file watching when executing tests in `run` mode
     finalConfig.watchOptions = {
       ignored: '**/*',
-    };
+    }
   }
 
   // @ts-ignore
   return {
     ...finalConfig,
-  };
+  }
 }

--- a/src/makeRspackConfig.ts
+++ b/src/makeRspackConfig.ts
@@ -1,14 +1,14 @@
-import { debug as debugFn } from 'debug';
-import * as path from 'path';
-import { merge } from 'webpack-merge';
-import { importModule } from 'local-pkg';
-import type { Configuration, EntryObject } from '@rspack/core';
-import { makeCypressRspackConfig } from './makeDefaultRspackConfig';
-import type { CreateFinalRspackConfig } from './createRspackDevServer';
-import { configFiles } from './constants';
-import { dynamicImport } from './dynamic-import';
+import { debug as debugFn } from 'debug'
+import * as path from 'path'
+import { merge } from 'webpack-merge'
+import { importModule } from 'local-pkg'
+import type { Configuration, EntryObject } from '@rspack/core'
+import { makeCypressRspackConfig } from './makeDefaultRspackConfig'
+import type { CreateFinalRspackConfig } from './createRspackDevServer'
+import { configFiles } from './constants'
+import { dynamicImport } from './dynamic-import'
 
-const debug = debugFn('cypress:rspack-dev-server:makeRspackConfig');
+const debug = debugFn('cypress:rspack-dev-server:makeRspackConfig')
 
 const removeList = [
   // We provide a webpack-html-plugin config pinned to a specific version (4.x)
@@ -23,9 +23,9 @@ const removeList = [
   // devServerEvents). Removing this plugin can prevent double-refreshes
   // in some setups.
   'HotModuleReplacementPlugin',
-];
+]
 
-export const CYPRESS_RSPACK_ENTRYPOINT = path.resolve(__dirname, 'browser.js');
+export const CYPRESS_RSPACK_ENTRYPOINT = path.resolve(__dirname, 'browser.js')
 
 /**
  * Removes and/or modifies certain plugins known to conflict
@@ -35,102 +35,98 @@ function modifyRspackConfigForCypress(rspackConfig: Partial<Configuration>) {
   if (rspackConfig?.plugins) {
     rspackConfig.plugins = rspackConfig.plugins.filter(
       (plugin) =>
-        !removeList.includes('raw' in plugin ? plugin.raw().name : plugin.constructor.name)
-    );
+        !removeList.includes('raw' in plugin ? plugin.raw().name : plugin.constructor.name),
+    )
   }
 
-  delete rspackConfig.entry;
-  delete rspackConfig.output;
+  delete rspackConfig.entry
+  delete rspackConfig.output
 
-  return rspackConfig;
+  return rspackConfig
 }
 
 async function getRspackConfigFromProjectRoot(projectRoot: string) {
-  const { findUp } = await dynamicImport<typeof import('find-up')>('find-up');
+  const { findUp } = await dynamicImport<typeof import('find-up')>('find-up')
 
-  return await findUp(configFiles, { cwd: projectRoot });
+  return await findUp(configFiles, { cwd: projectRoot })
 }
 
 /**
  * Creates a rspack 0 compatible rspack "configuration"
  * to pass to the sourced rspack function
  */
-export async function makeRspackConfig(
-  config: CreateFinalRspackConfig,
-) {
-  let userRspackConfig = config.devServerConfig.rspackConfig;
-  const frameworkRspackConfig = config.frameworkConfig as Partial<Configuration>;
+export async function makeRspackConfig(config: CreateFinalRspackConfig) {
+  let userRspackConfig = config.devServerConfig.rspackConfig
+  const frameworkRspackConfig = config.frameworkConfig as Partial<Configuration>
   const {
-    cypressConfig: {
-      projectRoot,
-      supportFile,
-    },
+    cypressConfig: { projectRoot, supportFile },
     specs: files,
     framework,
-  } = config.devServerConfig;
+  } = config.devServerConfig
 
   if (!userRspackConfig && !frameworkRspackConfig) {
-    debug('Not user or framework rspack config received. Trying to automatically source it');
+    debug('Not user or framework rspack config received. Trying to automatically source it')
 
-    const configFile = await getRspackConfigFromProjectRoot(projectRoot);
+    const configFile = await getRspackConfigFromProjectRoot(projectRoot)
 
     if (configFile) {
-      debug('found rspack config %s', configFile);
-      const sourcedConfig = await importModule(configFile);
+      debug('found rspack config %s', configFile)
+      const sourcedConfig = await importModule(configFile)
 
-      debug('config contains %o', sourcedConfig);
+      debug('config contains %o', sourcedConfig)
       if (sourcedConfig && typeof sourcedConfig === 'object') {
-        userRspackConfig = sourcedConfig.default ?? sourcedConfig;
+        userRspackConfig = sourcedConfig.default ?? sourcedConfig
       }
     }
 
     if (!userRspackConfig) {
-      debug('could not find rspack.config!');
+      debug('could not find rspack.config!')
       if (config.devServerConfig?.onConfigNotFound) {
-        config.devServerConfig.onConfigNotFound('webpack', projectRoot, configFiles);
+        config.devServerConfig.onConfigNotFound('webpack', projectRoot, configFiles)
         // The config process will be killed from the parent, but we want to early exit so we don't get
         // any additional errors related to not having a config
-        process.exit(0);
+        process.exit(0)
       } else {
-        throw new Error(`Your Cypress devServer config is missing a required webpackConfig property, since we could not automatically detect one.\nPlease add one to your ${ config.devServerConfig.cypressConfig.configFile }`);
+        throw new Error(
+          `Your Cypress devServer config is missing a required webpackConfig property, since we could not automatically detect one.\nPlease add one to your ${config.devServerConfig.cypressConfig.configFile}`,
+        )
       }
     }
   }
 
-  userRspackConfig = typeof userRspackConfig === 'function'
-    ? await userRspackConfig()
-    : userRspackConfig;
+  userRspackConfig =
+    typeof userRspackConfig === 'function' ? await userRspackConfig() : userRspackConfig
 
   const userAndFrameworkWebpackConfig = modifyRspackConfigForCypress(
     merge(frameworkRspackConfig ?? {}, userRspackConfig ?? {}),
-  );
+  )
 
-  debug(`User passed in user and framework webpack config with values %o`, userAndFrameworkWebpackConfig);
-  debug(`New webpack entries %o`, files);
-  debug(`Project root`, projectRoot);
-  debug(`Support file`, supportFile);
-
-  const mergedConfig = merge(
+  debug(
+    `User passed in user and framework webpack config with values %o`,
     userAndFrameworkWebpackConfig,
-    makeCypressRspackConfig(config),
-  );
+  )
+  debug(`New webpack entries %o`, files)
+  debug(`Project root`, projectRoot)
+  debug(`Support file`, supportFile)
+
+  const mergedConfig = merge(userAndFrameworkWebpackConfig, makeCypressRspackConfig(config))
 
   // Some frameworks (like Next.js) change this value which changes the path we would need to use to fetch our spec.
   // (eg, http://localhost:xxxx/<dev-server-public-path>/static/chunks/spec-<x>.js). Deleting this key to normalize
   // the spec URL to `*/spec-<x>.js` which we need to know up-front so we can fetch the sourcemaps.
-  delete mergedConfig.output?.chunkFilename;
+  delete mergedConfig.output?.chunkFilename
 
   // Angular loads global styles and polyfills via script injection in the index.html
   if (framework === 'angular') {
     mergedConfig.entry = {
-      ...(mergedConfig.entry as EntryObject) || {},
+      ...((mergedConfig.entry as EntryObject) || {}),
       'cypress-entry': CYPRESS_RSPACK_ENTRYPOINT,
-    };
+    }
   } else {
-    mergedConfig.entry = CYPRESS_RSPACK_ENTRYPOINT;
+    mergedConfig.entry = CYPRESS_RSPACK_ENTRYPOINT
   }
 
-  debug('Merged rspack config %o', mergedConfig);
+  debug('Merged rspack config %o', mergedConfig)
 
-  return mergedConfig;
+  return mergedConfig
 }


### PR DESCRIPTION
When I tried to edit and save the file, the file would always be reformatted by prettier, so explicitly install prettier to unify the format.

Install the eslint simply since we have command with `lint`