### PR TITLE
fix: resolve component index file when rspack config is in sub dir

### DIFF
--- a/src/makeDefaultRspackConfig.ts
+++ b/src/makeDefaultRspackConfig.ts
@@ -52,7 +52,7 @@ export function makeCypressRspackConfig(config: CreateFinalRspackConfig): Config
     },
     plugins: [
       new HtmlRspackPlugin({
-        template: path.join(projectRoot, indexHtmlFile),
+        template: path.posix.join(projectRoot, indexHtmlFile),
         filename: 'index.html',
       }),
       new CypressCTRspackPlugin({

--- a/src/makeDefaultRspackConfig.ts
+++ b/src/makeDefaultRspackConfig.ts
@@ -52,7 +52,7 @@ export function makeCypressRspackConfig(config: CreateFinalRspackConfig): Config
     },
     plugins: [
       new HtmlRspackPlugin({
-        template: indexHtmlFile,
+        template: path.join(projectRoot, indexHtmlFile),
         filename: 'index.html',
       }),
       new CypressCTRspackPlugin({

--- a/test/__snapshots__/makeDefaultRspackConfig.spec.ts.snap
+++ b/test/__snapshots__/makeDefaultRspackConfig.spec.ts.snap
@@ -21,6 +21,7 @@ exports[`makeCypressRspackConfig should return a valid Configuration object 1`] 
       "_events": {},
       "_eventsCount": 0,
       "_maxListeners": undefined,
+      Symbol(shapeMode): false,
       Symbol(kCapture): false,
     },
     "files": [],

--- a/test/__snapshots__/makeDefaultRspackConfig.spec.ts.snap
+++ b/test/__snapshots__/makeDefaultRspackConfig.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`makeCypressRspackConfig should return a valid Configuration object 1`] 
     "_args": [
       {
         "filename": "index.html",
-        "template": "path/to/indexHtmlFile",
+        "template": "path/to/project/path/to/indexHtmlFile",
       },
     ],
     "affectedHooks": undefined,
@@ -21,7 +21,6 @@ exports[`makeCypressRspackConfig should return a valid Configuration object 1`] 
       "_events": {},
       "_eventsCount": 0,
       "_maxListeners": undefined,
-      Symbol(shapeMode): false,
       Symbol(kCapture): false,
     },
     "files": [],

--- a/test/makeDefaultRspackConfig.spec.ts
+++ b/test/makeDefaultRspackConfig.spec.ts
@@ -67,6 +67,7 @@ describe('experimentalJustInTimeCompile', () => {
     specs: [],
     cypressConfig: {
       projectRoot: '.',
+      indexHtmlFile: 'path/to/supportFile',
       devServerPublicPathRoute: '/test-public-path',
       justInTimeCompile: true,
       baseUrl: null,


### PR DESCRIPTION
The code previously assumed that the component test index file was relative to the directory of the rspack config file, but that's not always true, for example when your rspack config file is in a subdirectory.