### PR TITLE
fix: avoid filename conflict

### DIFF
--- a/dist/makeDefaultRspackConfig.js
+++ b/dist/makeDefaultRspackConfig.js
@@ -28,7 +28,7 @@ function makeCypressRspackConfig(config) {
         mode: 'development',
         optimization,
         output: {
-            filename: '[name].js',
+            filename: '[name].[contenthash].js',
             path: OUTPUT_PATH,
             publicPath,
         },

--- a/src/makeDefaultRspackConfig.ts
+++ b/src/makeDefaultRspackConfig.ts
@@ -46,7 +46,7 @@ export function makeCypressRspackConfig(config: CreateFinalRspackConfig): Config
     mode: 'development',
     optimization,
     output: {
-      filename: '[name].js',
+      filename: '[name].[contenthash].js',
       path: OUTPUT_PATH,
       publicPath,
     },


### PR DESCRIPTION
This fixes a 'Loading chunk error' issue that happens sometimes in the CI. The test is running correctly but sometimes the test fails to load the test file in the CI.