### PR TITLE
fix: #49 fix the bug of split chunks algorithm with rspack 2

### DIFF
--- a/dist/makeDefaultRspackConfig.js
+++ b/dist/makeDefaultRspackConfig.js
@@ -15,7 +15,7 @@ function makeCypressRspackConfig(config) {
         // rspack does not recognize the sideEffects flag in the package.json and thus files are not unintentionally
         // dropped during testing in production mode.
         sideEffects: false,
-        splitChunks: { chunks: 'all' },
+        splitChunks: false,
     };
     const publicPath = path_1.default.sep === posixSeparator
         ? path_1.default.join(devServerPublicPathRoute, posixSeparator)

--- a/src/makeDefaultRspackConfig.ts
+++ b/src/makeDefaultRspackConfig.ts
@@ -31,7 +31,7 @@ export function makeCypressRspackConfig(config: CreateFinalRspackConfig): Config
     // rspack does not recognize the sideEffects flag in the package.json and thus files are not unintentionally
     // dropped during testing in production mode.
     sideEffects: false,
-    splitChunks: { chunks: 'all' },
+    splitChunks: false,
   }
 
   const publicPath =

--- a/test/makeDefaultRspackConfig.spec.ts
+++ b/test/makeDefaultRspackConfig.spec.ts
@@ -40,7 +40,7 @@ describe('makeCypressRspackConfig', () => {
     expect(result.mode).toBe('development')
     expect(result.optimization).toEqual({
       sideEffects: false,
-      splitChunks: { chunks: 'all' },
+      splitChunks: false,
     })
     expect(result.plugins).toMatchSnapshot()
     expect(result.devtool).toBe('inline-source-map')


### PR DESCRIPTION
## Summary

Fixes #49 — Disables `splitChunks` in the default Cypress rspack config to prevent module loading failures with Rspack v2 on Linux.

## Problem

The `splitChunks: { chunks: 'all' }` setting (inherited from Cypress's official `@cypress/webpack-dev-server`) causes Rspack v2's chunk splitting algorithm to produce broken chunk boundaries on Linux. A transitive dependency gets placed in a separate chunk that hasn't loaded when the spec module evaluates, resulting in:

```
TypeError: Cannot read properties of undefined (reading 'call')
  at __webpack_require__
```

The issue is **platform-specific** — it reproduces on Linux (`@rspack/binding-linux-x64-gnu`) but not on macOS (`@rspack/binding-darwin-arm64`) with identical `node_modules`.

## Why this fix is safe

Chunk splitting is not beneficial for Cypress component testing — all code runs in a single test iframe. There's no performance gain from shared vendor chunks in this context. The `splitChunks` config was inherited from Cypress's webpack-dev-server where it works correctly with webpack's chunk loading runtime, but Rspack v2's rewritten `@rspack/dev-server` (no longer based on `webpack-dev-server`) handles chunk loading differently.

## Changes

- `src/makeDefaultRspackConfig.ts`: `splitChunks: { chunks: 'all' }` → `splitChunks: false`
- `dist/makeDefaultRspackConfig.js`: same change in compiled output