### PR TITLE
fix: default devtool to eval-cheap-source-map and stop overriding user's devtool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ The entry point is `src/index.ts` which exports `devServer()`. The flow:
 1. **`devServer.ts`** — detects framework (react/vue/svelte/angular/next), resolves presets, orchestrates everything
 2. **`helpers/sourceRelativeRspackModules.ts`** — sources `@rspack/core` and `@rspack/dev-server` from the user's project (or framework) via `dynamicAbsoluteImport`, installs `Module._load`/`_resolveFilename` hooks to ensure consistent rspack resolution
 3. **`makeRspackConfig.ts`** — auto-discovers user's rspack/webpack config via `find-up`, merges user + framework + Cypress configs with `webpack-merge`, removes conflicting plugins (HtmlWebpackPlugin, HtmlRspackPlugin, HMR)
-4. **`makeDefaultRspackConfig.ts`** — builds Cypress-specific rspack config: dev mode, inline source maps, HtmlRspackPlugin, CypressCTRspackPlugin
+4. **`makeDefaultRspackConfig.ts`** — builds Cypress-specific rspack config: dev mode, HtmlRspackPlugin, CypressCTRspackPlugin. Note: it deliberately does NOT set `devtool` — `makeRspackConfig.ts` applies a default (`eval-cheap-source-map`) only when the user/framework config didn't set one, so a user's `devtool` is respected (this config is merged last and would otherwise clobber it)
 5. **`createRspackDevServer.ts`** — instantiates `RspackDevServer` with final config
 6. **`CypressCTRspackPlugin.ts`** — custom rspack plugin that tracks spec files, handles `dev-server:specs:changed` events, injects context into the loader
 7. **`loader.ts`** — rspack loader that generates dynamic imports for spec files with chunk names, handles support file injection
@@ -65,3 +65,4 @@ Related issues:
 - Prettier: single quotes, no semicolons, 100 char width
 - Debug logging uses the `debug` library with namespace `cypress-rspack-dev-server:<module>`
 - Constants are UPPER_SNAKE_CASE, classes PascalCase, functions/variables camelCase
+- Never mention Claude Code (or any "Generated with Claude"/"Co-Authored-By: Claude" attribution) in code comments or commit messages

--- a/dist/makeDefaultRspackConfig.js
+++ b/dist/makeDefaultRspackConfig.js
@@ -44,7 +44,6 @@ function makeCypressRspackConfig(config) {
                 indexHtmlFile,
             }),
         ],
-        devtool: 'inline-source-map',
     };
     if (isRunMode) {
         // if justInTimeCompile is configured, we need to watch for file changes

--- a/dist/makeRspackConfig.js
+++ b/dist/makeRspackConfig.js
@@ -96,6 +96,12 @@ async function makeRspackConfig(config) {
     debug(`Project root`, projectRoot);
     debug(`Support file`, supportFile);
     const mergedConfig = (0, webpack_merge_1.merge)(userAndFrameworkRspackConfig, (0, makeDefaultRspackConfig_1.makeCypressRspackConfig)(config));
+    // Default to `eval-cheap-source-map` (line-accurate maps, but far lighter than
+    // inline-source-map) only when the user/framework config didn't set one. Not set in
+    // makeCypressRspackConfig because that is merged last and would clobber the user's choice.
+    if (mergedConfig.devtool === undefined) {
+        mergedConfig.devtool = 'eval-cheap-source-map';
+    }
     // Some frameworks (like Next.js) change this value which changes the path we would need to use to fetch our spec.
     // (eg, http://localhost:xxxx/<dev-server-public-path>/static/chunks/spec-<x>.js). Deleting this key to normalize
     // the spec URL to `*/spec-<x>.js` which we need to know up-front so we can fetch the sourcemaps.

--- a/src/makeDefaultRspackConfig.ts
+++ b/src/makeDefaultRspackConfig.ts
@@ -63,7 +63,6 @@ export function makeCypressRspackConfig(config: CreateFinalRspackConfig): Config
         indexHtmlFile,
       }),
     ],
-    devtool: 'inline-source-map',
   }
 
   if (isRunMode) {

--- a/src/makeRspackConfig.ts
+++ b/src/makeRspackConfig.ts
@@ -124,6 +124,13 @@ export async function makeRspackConfig(config: CreateFinalRspackConfig): Promise
 
   const mergedConfig = merge(userAndFrameworkRspackConfig, makeCypressRspackConfig(config))
 
+  // Default to `eval-cheap-source-map` (line-accurate maps, but far lighter than
+  // inline-source-map) only when the user/framework config didn't set one. Not set in
+  // makeCypressRspackConfig because that is merged last and would clobber the user's choice.
+  if (mergedConfig.devtool === undefined) {
+    mergedConfig.devtool = 'eval-cheap-source-map'
+  }
+
   // Some frameworks (like Next.js) change this value which changes the path we would need to use to fetch our spec.
   // (eg, http://localhost:xxxx/<dev-server-public-path>/static/chunks/spec-<x>.js). Deleting this key to normalize
   // the spec URL to `*/spec-<x>.js` which we need to know up-front so we can fetch the sourcemaps.

--- a/test/makeDefaultRspackConfig.spec.ts
+++ b/test/makeDefaultRspackConfig.spec.ts
@@ -43,7 +43,8 @@ describe('makeCypressRspackConfig', () => {
       splitChunks: false,
     })
     expect(result.plugins).toMatchSnapshot()
-    expect(result.devtool).toBe('inline-source-map')
+    // devtool is defaulted in makeRspackConfig, not here (this config is merged last).
+    expect(result.devtool).toBeUndefined()
     expect(result.optimization?.sideEffects).toBe(false)
   })
 })

--- a/test/makeRspackConfig.spec.ts
+++ b/test/makeRspackConfig.spec.ts
@@ -49,6 +49,27 @@ describe('makeRspackConfig', () => {
     expect(result.resolve?.alias).toEqual({ '@': '/src' })
   })
 
+  it('defaults devtool to `eval-cheap-source-map` when the user config does not set one', async () => {
+    const result = await makeRspackConfig({
+      devServerConfig: { ...baseDevServerConfig, rspackConfig: {} },
+      sourceRspackModulesResult: createModuleMatrixResult(),
+    })
+
+    expect(result.devtool).toBe('eval-cheap-source-map')
+  })
+
+  it('respects the user-provided devtool over the default', async () => {
+    const result = await makeRspackConfig({
+      devServerConfig: {
+        ...baseDevServerConfig,
+        rspackConfig: { devtool: 'eval-cheap-module-source-map' },
+      },
+      sourceRspackModulesResult: createModuleMatrixResult(),
+    })
+
+    expect(result.devtool).toBe('eval-cheap-module-source-map')
+  })
+
   it('accepts rspack config as a function', async () => {
     const rspackConfig = () => ({
       resolve: { alias: { '@fn': '/fn-src' } },


### PR DESCRIPTION
## Problem

`makeCypressRspackConfig` hardcoded `devtool: 'inline-source-map'`. Because that config object is merged **last** in `makeRspackConfig` (`merge(userAndFrameworkRspackConfig, makeCypressRspackConfig(config))`), it silently overrode any `devtool` a user set in their own rspack config. It's also the heaviest devtool (full source maps, base64-inlined into every bundle), which drives up the dev-server's peak memory for large eager component-test graphs.

Downstream projects have had to `patch-package` this library to work around it.

## Fix

- Remove the hardcoded `devtool` from `makeCypressRspackConfig`.
- In `makeRspackConfig`, default `devtool` to `'eval-cheap-source-map'` **only when** the user/framework config didn't set one.

Result:
- Lighter default — `eval-cheap-source-map` gives line-accurate source maps while being far cheaper than `inline-source-map`, lowering peak memory.
- A user's `devtool` is now **respected** instead of clobbered (e.g. a memory-constrained CI can opt down to `eval`).

## Compatibility note

This changes the default source-map behavior for **all** consumers, not just those who were patching it: anyone who wasn't setting `devtool` themselves goes from full inline source maps to a lighter cheap variant. Intended trade-off (memory over full column-accurate maps); worth a minor version bump + changelog note.

## Tests

- `pnpm test` — 24 passed, incl. new cases for "default applies when unset" and "user devtool wins"
- `pnpm check-ts` — clean
- `pnpm lint` — clean